### PR TITLE
Fixed inconsistent echo termination condition

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -31,7 +31,7 @@ def p2p_echo():
             # Ensure that what we sent is what we got back
             assert(echo == byte_msg)
             # If the msg is X, then terminate the connection
-            if msg.lower() == 'x' or msg.lower() == "exit" or msg.lower() == "quit":
+            if msg.lower() == 'X' or msg.lower() == "exit" or msg.lower() == "quit":
                 sconn.close()
                 break
     except socket.error:


### PR DESCRIPTION
~Both [`p2p_server()`](https://github.com/Elec5616/skynet_intro/blob/accecbb0eadced7f6b153fc9a1ded78ba3dc1cbf/lib/p2p.py#L34) and the comment above changed line suggest uppercase `X`.~

