### PR TITLE
Fixed echo server termination condition

### DIFF
--- a/lib/p2p.py
+++ b/lib/p2p.py
@@ -31,8 +31,9 @@ def echo_server(sconn):
         data = sconn.recv()
         print("ECHOING>", data)
         sconn.send(data)
-        msg = data.decode('ascii')
-        if msg.lower() == 'x' or msg.lower() == 'exit' or msg.lower() == 'quit':            
+        head_len = 4 if len(data) >= 4 else len(data)
+        msg_head = data[:head_len].decode('ascii')
+        if msg_head.lower() == 'x' or msg_head.lower() == 'exit' or msg_head.lower() == 'quit':            
             print("Closing connection...")
             sconn.close()
             return

--- a/lib/p2p.py
+++ b/lib/p2p.py
@@ -31,7 +31,8 @@ def echo_server(sconn):
         data = sconn.recv()
         print("ECHOING>", data)
         sconn.send(data)
-        if data == b'X' or data == b'exit' or data == b'quit':
+        msg = data.decode('ascii')
+        if msg.lower() == 'x' or msg.lower() == 'exit' or msg.lower() == 'quit':            
             print("Closing connection...")
             sconn.close()
             return


### PR DESCRIPTION
Fixed echo server termination condition to check for `'x'`, `'quit'` and `'exit'` in any casing to be consistent with echo client.

Currently server thread crashes on client messages like `'x'`, `'Quit'`, `'EXIT'` etc.